### PR TITLE
[fix/240822] 최종 테스트 후 수정 사항 반영

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1048,20 +1048,22 @@ input.error {
 /* 게시글 상세보기 - 댓글 */
 /* 댓글 작성 */
 .comment_write {
-	padding: 32px;
+	padding: 32px 24px;
 	border: 1px solid var(--border-color);
 	border-radius: var(--br-md);
 }
 .comment_write_title {
-	line-height: var(--fs-h5);
-	font-size: var(--fs-h5);
+	line-height: var(--fs-h6);
+	font-size: var(--fs-h6);
 	font-weight: var(--fw-bold);
+}
+.comment_write_body {
+	margin: 16px 0;
 }
 .comment_write textarea {
 	width: 100%;
 	min-height: 112px;
 	padding: 12px 16px;
-	margin: 16px 0;
 	border: 1px solid var(--border-color);
 	border-radius: var(--br-md);
 	background: var(--background-color);
@@ -1080,8 +1082,8 @@ input.error {
 }
 .comments_title {
 	margin-bottom: 32px;
-	line-height: var(--fs-h5);
-	font-size: var(--fs-h5);
+	line-height: var(--fs-h6);
+	font-size: var(--fs-h6);
 	font-weight: var(--fw-bold);
 }
 .comment_list_item {
@@ -1575,8 +1577,8 @@ input.error {
 		--fs-h4: 24px;
 		--fs-h5: 22px;
 		--fs-h6: 20px;
-		--fs-caption: 14px;
-		--fs-caption-sm: 12px;
+		--fs-caption: 12px;
+		--fs-caption-sm: 10px;
 	}
 	/* common */
 	.page_wrap {
@@ -1727,19 +1729,28 @@ input.error {
 	.sign_box {
 		width: 100%;
 	}
-	/* boardList: 건드릴 것 없음 */
+	/* boardList */
+	.board_item .title {
+		font-size: var(--fs-h6);
+	}
 	/* boardDetail */
 	.board_detail_box {
 		padding: 20px;
 	}
 	.board_detail_box .board_detail_title {
-		line-height: var(--lh-h4);
-		font-size: var(--fs-h4);
+		line-height: var(--lh-h6);
+		font-size: var(--fs-h6);
 	}
 	.comment_write {
 		padding: 16px;
 	}
 	/* board write */
+	.board_input_title input {
+		font-size: var(--fs-h6);
+	}
+	.board_input_title input::placeholder {
+		font-size: var(--fs-h6);
+	}
 	.board_write_box {
 		padding: 16px;
 	}
@@ -1756,6 +1767,9 @@ input.error {
 	}
 	.board_write_box .toastui-editor-contents {
 		font-size: 16px;
+	}
+	.board_write_box .toastui-editor-popup {
+		margin-left: 0;
 	}
 	.board_editor_button_wrap {
 		flex-direction: column;

--- a/client/src/components/BoardComment.tsx
+++ b/client/src/components/BoardComment.tsx
@@ -19,18 +19,6 @@ const BoardComment = ({
 	const [isLoading, setIsLoading] = useState(true);
 
 	const fetchCommentData = async () => {
-		// const accessToken = getAccessToken();
-		// if (accessToken) {
-		// 	axios
-		// 		.get(`${api}/api/v1/comment?postId=${postId}`)
-		// 		.then((res) => {
-		// 			// console.log(res.data.data); 성공적으로 삭제해도 isRemoved 떠서 확인필요
-		// 			setCommentList(res.data.data.comments);
-		// 			setIsLoading(false);
-		// 		})
-		// 		.catch((_) => {});
-		// }
-
 		try {
 			const response = await axios.get(
 				`${api}/api/v1/comment?postId=${postId}`
@@ -84,20 +72,26 @@ const BoardComment = ({
 			<div className="comment_write">
 				<dl>
 					<dt className="comment_write_title">댓글 작성</dt>
-					<dd>
-						<textarea
-							placeholder="댓글을 작성하세요"
-							onChange={(e) => handleChangeComment(e)}
-							value={comment}
-						></textarea>
+					<dd className="comment_write_body">
+						{memberId === undefined ? (
+							"로그인 후 댓글 작성이 가능합니다."
+						) : (
+							<textarea
+								placeholder="댓글을 작성하세요"
+								onChange={(e) => handleChangeComment(e)}
+								value={comment}
+							></textarea>
+						)}
 					</dd>
 				</dl>
-				<Button
-					buttonType="primary"
-					buttonSize="big"
-					buttonLabel="댓글 입력"
-					onClick={handleClickCommentSubmit}
-				/>
+				{memberId === undefined ? null : (
+					<Button
+						buttonType="primary"
+						buttonSize="big"
+						buttonLabel="댓글 입력"
+						onClick={handleClickCommentSubmit}
+					/>
+				)}
 			</div>
 			{isLoading ? (
 				<div className="comments_list_wrap">댓글 목록을 불러오는 중입니다.</div>

--- a/client/src/components/Boarditem.tsx
+++ b/client/src/components/Boarditem.tsx
@@ -12,10 +12,15 @@ interface BoardItemData {
 	title: string;
 	content: string;
 	createdAt: string;
-	timeInfo: string;
 }
 
 const BoardItem = ({ data }: { data: BoardItemData }) => {
+	//날짜 변경 함수
+	const changedDate = (date: string) => {
+		const newDate = new Date(date);
+		return newDate.toLocaleString("ko-KR");
+	};
+
 	return (
 		<div className="board_item">
 			<a href={`/${data.postId}`} title={data.title}>
@@ -36,7 +41,7 @@ const BoardItem = ({ data }: { data: BoardItemData }) => {
 				</div>
 				<h3 className="title">{data.title}</h3>
 				<div className="board_item_element_wrap">
-					<p className="board_date">{data.timeInfo}</p>
+					<p className="board_date">{changedDate(data.createdAt)}</p>
 					<p className="board_writer">{data.memberName}</p>
 				</div>
 			</a>

--- a/client/src/components/CommentItem.tsx
+++ b/client/src/components/CommentItem.tsx
@@ -12,10 +12,7 @@ const CommentItem = ({ data }: { data: any }) => {
 	return (
 		<div className="board_item">
 			<div className="board_item_element_wrap">
-				<a
-					href={`/board/${data.boardId}-${data.boardName}/${data.postId}`}
-					className="link em"
-				>
+				<a href={`/${data.postId}`} className="link em">
 					게시글 바로가기
 				</a>
 				<div className="board_info">

--- a/client/src/components/CommentListItem.tsx
+++ b/client/src/components/CommentListItem.tsx
@@ -70,7 +70,7 @@ const CommentListItem = ({
 			const accessToken = getAccessToken();
 			if (accessToken) {
 				axios
-					.get(`${api}/api/v1/comment/${data.id}`, {
+					.delete(`${api}/api/v1/comment/delete/${data.id}`, {
 						headers: { Authorization: accessToken },
 					})
 					.then((res) => {
@@ -119,104 +119,98 @@ const CommentListItem = ({
 
 	return (
 		<>
-			{data.isRemoved ? (
-				<div className="comment_removed">삭제된 댓글입니다.</div>
-			) : (
-				<>
-					<div className="comment_head">
-						<div className="comment_user_profile">
-							<div className="user_img_wrap"></div>
-							<h5 className="user_name">{data.memberName}</h5>
-							<div className="comment_ceated_time">{data.createdAt}</div>
-						</div>
-						<div className="comment_likes">{data.voteCount}</div>
+			<div className="comment_head">
+				<div className="comment_user_profile">
+					<div className="user_img_wrap"></div>
+					<h5 className="user_name">{data.memberName}</h5>
+					<div className="comment_ceated_time">{data.createdAt}</div>
+				</div>
+				<div className="comment_likes">{data.voteCount}</div>
+			</div>
+			{isUpdating ? (
+				<div className="comment_body">
+					<textarea
+						className="comment_content_textarea"
+						onChange={(e) => handleChangeComment(e)}
+					>
+						{comment}
+					</textarea>
+					<div className="comment_update_btn_wrap">
+						<button
+							className="comment_btn update"
+							onClick={handleClickCommentUpdateComplete}
+						>
+							수정완료
+						</button>
+						<button
+							className="comment_btn delete"
+							onClick={handleClickCommentDelete}
+						>
+							삭제
+						</button>
 					</div>
-					{isUpdating ? (
-						<div className="comment_body">
-							<textarea
-								className="comment_content_textarea"
-								onChange={(e) => handleChangeComment(e)}
+				</div>
+			) : (
+				<div className="comment_body">
+					<div className="comment_content">{comment}</div>
+					{memberId === data.memberId ? (
+						<div className="comment_update_btn_wrap">
+							<button
+								className="comment_btn update"
+								onClick={handleClickCommentUpdate}
 							>
-								{comment}
-							</textarea>
-							<div className="comment_update_btn_wrap">
+								수정
+							</button>
+							<button
+								className="comment_btn delete"
+								onClick={handleClickCommentDelete}
+							>
+								삭제
+							</button>
+						</div>
+					) : null}
+				</div>
+			)}
+			{isChild ? null : (
+				<div className="comment_reply_btns_wrap">
+					{/* {data.children!.length > 0 ? (
+					<button className="comment_reply_btn toggle_view_child_comments show">
+						답글 더보기
+					</button>
+				) : null} */}
+					{isReplyWriting ? (
+						<div className="reply_create_wrap">
+							<div>
+								<textarea
+									placeholder="답글을 작성하세요"
+									onChange={(e) => handleChangeReply(e)}
+									value={reply}
+								></textarea>
+							</div>
+							<div className="reply_create_btns">
 								<button
-									className="comment_btn update"
-									onClick={handleClickCommentUpdateComplete}
+									className="reply_create_btn reply_cancel"
+									onClick={handleClicktoggleReply}
 								>
-									수정완료
+									취소
 								</button>
 								<button
-									className="comment_btn delete"
-									onClick={handleClickCommentDelete}
+									className="reply_create_btn reply_submit"
+									onClick={handleClickReplySubmit}
 								>
-									삭제
+									작성 완료
 								</button>
 							</div>
 						</div>
 					) : (
-						<div className="comment_body">
-							<div className="comment_content">{comment}</div>
-							{memberId === data.memberId ? (
-								<div className="comment_update_btn_wrap">
-									<button
-										className="comment_btn update"
-										onClick={handleClickCommentUpdate}
-									>
-										수정
-									</button>
-									<button
-										className="comment_btn delete"
-										onClick={handleClickCommentDelete}
-									>
-										삭제
-									</button>
-								</div>
-							) : null}
-						</div>
+						<button
+							className="comment_reply_btn create_comment_child"
+							onClick={handleClicktoggleReply}
+						>
+							답글
+						</button>
 					)}
-					{isChild ? null : (
-						<div className="comment_reply_btns_wrap">
-							{/* {data.children!.length > 0 ? (
-								<button className="comment_reply_btn toggle_view_child_comments show">
-									답글 더보기
-								</button>
-							) : null} */}
-							{isReplyWriting ? (
-								<div className="reply_create_wrap">
-									<div>
-										<textarea
-											placeholder="답글을 작성하세요"
-											onChange={(e) => handleChangeReply(e)}
-											value={reply}
-										></textarea>
-									</div>
-									<div className="reply_create_btns">
-										<button
-											className="reply_create_btn reply_cancel"
-											onClick={handleClicktoggleReply}
-										>
-											취소
-										</button>
-										<button
-											className="reply_create_btn reply_submit"
-											onClick={handleClickReplySubmit}
-										>
-											작성 완료
-										</button>
-									</div>
-								</div>
-							) : (
-								<button
-									className="comment_reply_btn create_comment_child"
-									onClick={handleClicktoggleReply}
-								>
-									답글
-								</button>
-							)}
-						</div>
-					)}
-				</>
+				</div>
 			)}
 		</>
 	);

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,7 +1,7 @@
 // import { ReactComponent as iconMenu } from "./../assets/icon _menu_.svg";
 import { useState, Dispatch, useEffect } from "react";
 import iconMenu from "./../assets/icon_menu.svg";
-import { getAccessToken } from "../assets/tokenActions";
+import { getAccessToken, removeAccessToken } from "../assets/tokenActions";
 import axios from "axios";
 import { userDataType } from "./../App";
 import LoginInfo from "./LoginInfo";
@@ -37,6 +37,7 @@ const Header = (props: HeaderProps) => {
 				})
 				.catch((error) => {
 					props.setIsLogin(false);
+					removeAccessToken();
 				});
 		} else props.setIsLogin(false);
 	}, []);
@@ -46,7 +47,7 @@ const Header = (props: HeaderProps) => {
 	return (
 		<header className="header">
 			<h1>
-				<a href="/" className="logo" title="JBaccount 홈">
+				<a href="/" className="logo" title="cpayusin 홈">
 					<img className="logo_img" src="/images/logo.png" />
 				</a>
 			</h1>

--- a/client/src/components/Input.tsx
+++ b/client/src/components/Input.tsx
@@ -16,6 +16,7 @@ export interface InputProps {
 	inputValue?: string; //값
 	isError?: boolean; //에러 여부
 	isReadonly?: boolean;
+	maxLength?: number;
 }
 
 const Input = ({
@@ -28,6 +29,7 @@ const Input = ({
 	inputValue,
 	isError,
 	isReadonly,
+	maxLength,
 }: InputProps) => {
 	const id = `jb-input-${Math.random()}` ?? inputAttr.id;
 	const handleOnchange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -46,6 +48,7 @@ const Input = ({
 					value={inputValue}
 					className={isError ? "error" : ""}
 					readOnly={!!isReadonly}
+					maxLength={maxLength}
 				/>
 				{children && children}
 			</div>

--- a/client/src/pages/BoardDetailEdit.tsx
+++ b/client/src/pages/BoardDetailEdit.tsx
@@ -40,7 +40,7 @@ const BoardDetailEdit = () => {
 	const navigate = useNavigate();
 	const [postdata, setPostData] = useState<postData>();
 	const params = useParams();
-	const [boardId, boardName] = params.boardInfo!.split("-");
+	const boardId = params.postId;
 	const [categoryItem, setCategoryItem] = useState<categoryDataType[]>([]); //카테고리 목록
 	const [nowCategoryId, setNowCategoryId] = useState(0); //현재 선택된 카테고리 id
 	const [selectValueCategory, setSelectValueCategory] = useState(""); //현재 선택된 카테고리
@@ -111,7 +111,7 @@ const BoardDetailEdit = () => {
 		};
 		axios
 			.patch(
-				`${api}/api/v1/post/update/${params.postId}`,
+				`http://13.124.241.118:8080/api/v1/post/update/${params.postId}`, //240828임시URL변경
 				formData,
 				postAxiosConfig
 			)

--- a/client/src/pages/BoardList.tsx
+++ b/client/src/pages/BoardList.tsx
@@ -32,7 +32,7 @@ const BoardList = ({ menuData }: { menuData: any[] }) => {
 	const [boardMap, setBoardMap] = useState({});
 	const [boardInfo, setBoardInfo] = useState({
 		boardName: params.boardInfo,
-		boardId: 0,
+		boardId: menuData.filter((el) => el.name === params.boardInfo)[0].id,
 		boardIsAdminOnly: false,
 	});
 	const [data, setData] = useState<any[]>([]);
@@ -56,6 +56,7 @@ const BoardList = ({ menuData }: { menuData: any[] }) => {
 			boardIsAdminOnly: boardMap[params.boardInfo!].isAdminOnly,
 		};
 		setBoardInfo(boardInfo);
+
 		axios
 			.get(`${api}/api/v1/post/board?id=${boardInfo.boardId}&page=1&size=8`)
 			.then((response) => {

--- a/client/src/pages/BoardWrite.tsx
+++ b/client/src/pages/BoardWrite.tsx
@@ -112,7 +112,7 @@ const BoardWrite = () => {
 	const uploadImage = async (formData: FormData, config: any) => {
 		try {
 			const res = await axios.post(
-				`${api}/api/v1/post/create`,
+				`http://13.124.241.118:8080/api/v1/post/create`, //240828임시URL변경
 				formData,
 				config
 			);
@@ -181,7 +181,11 @@ const BoardWrite = () => {
 				})
 			);
 			axios
-				.post(`${api}/api/v1/post/create`, newFormData, postAxiosConfig)
+				.post(
+					`http://13.124.241.118:8080/api/v1/post/create`,
+					newFormData,
+					postAxiosConfig
+				) //240828임시URL변경
 				.then((response) => {
 					const newPostId = response.data.data.id;
 					navigate(`/${newPostId}`);
@@ -230,12 +234,12 @@ const BoardWrite = () => {
 
 			axios
 				.patch(
-					`${api}/api/v1/post/update/${postId}`,
+					`http://13.124.241.118:8080/api/v1/post/update/${postId}`, //240828임시URL변경
 					newFormData,
 					postAxiosConfig
 				)
 				.then((_) => {
-					navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
+					navigate(`/board/${nowBoardData!.name}`);
 				})
 				.catch((error) => {
 					alert("게시판 등록을 실패했습니다.");
@@ -293,6 +297,7 @@ const BoardWrite = () => {
 								}}
 								setInputValue={setTitleValue}
 								inputValue={titleValue}
+								maxLength={50}
 							/>
 						</div>
 					</div>

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -37,18 +37,21 @@ const UserPage: React.FC<userPageProps> = ({ userData }) => {
 			alert("로그인이 필요한 서비스입니다.");
 			navigate(`/login`);
 		}
-		console.log(userData);
 	}, []);
 
 	return (
 		<div className="user_page_wrap">
 			<div className="user_profile">
-				{userData?.profileImage !== null ? null : (
-					<div className="profile_img_wrap">
-						<img src={iconUser} className="profile_img_default" />
-					</div>
-				)}
-
+				<div className="profile_img_wrap">
+					<img
+						src={
+							userData?.profileImage !== null
+								? userData?.profileImage
+								: iconUser
+						}
+						className="profile_img_default"
+					/>
+				</div>
 				<div className="user_info_wrap">
 					<p className="title_h4">{userData?.nickname}</p>
 					<p className="email">{userData?.email}</p>

--- a/client/src/pages/ValidateEmail.tsx
+++ b/client/src/pages/ValidateEmail.tsx
@@ -56,7 +56,6 @@ const ValidateEmail = ({
 			email: emailValue,
 			verificationCode: codeValue,
 		};
-		console.log(form);
 		axios
 			.post(`${api}/api/v1/verification`, form)
 			.then((response) => {
@@ -98,7 +97,9 @@ const ValidateEmail = ({
 					onClick={handleClickValidateCode}
 				/>
 				{canInputValidateCode ? (
-					<p className="validate_email_msg">인증코드가 전송되었습니다.</p>
+					<p className="validate_email_msg">
+						인증코드가 전송되었습니다. (유효시간 10분)
+					</p>
 				) : null}
 				{isValidateError ? (
 					<p className="validate_email_msg error">


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
8/31(토) 최종 통합테스트 대비 최소 요구사항 관련 버그 수정
- 모바일 반응형 UI 수정, 기존 스타일 수정
- 로그인 후에만 댓글 작성하도록 변경
- 댓글에 작성 날짜 반영(API 수정으로 인한 미반영 해결)
- 내가 쓴 댓글 게시글 이동 링크 수정
- 변경된 API 반영
- 로그인이 안 된 경우 토큰 삭제
- input에 글자제한 옵션 추가
- 게시글 정보 저장 수정, 수정 api 임시 변경된 api로 변경
- 게시글 목록 초기값 변경으로 새로고침시 없는 현상 수정
- 게시글 이미지 등록시 에러로 임시 api 반영, 생성 완료 후 게시글 이동 링크 수정 반영
- 사용자 프로필 이미지가 있는 경우 노출되도록 로직 수정
- 이메일 인증 유효시간 고지

# 느낀 점 및 어려운 점
- 이미지 저장 경로 임시 변경
게시글 생성시 이미지 저장시 기존과 다르게 정상적으로 반영이 되지 않는 문제가 있었습니다. cloudfront로 서버가 바뀌고 난 후 라서 임시로 기존에 작업했던 ec2경로로 변경하여 저장하도록 하여 해결되었습니다. 해당 부분에는 임시 api url을 반영했으므로 추후 수정을 위해 다음과 같은 주석을 달아놓았습니다.
`240828임시URL변경`
- 새로고침시 데이터가 없는 경우 해결
자꾸 새로고침해도 게시글 목록이 없다고 뜨는 경우가 있었는데, state의 초기값인 boardId 0으로 서버에 게시글 목록을 요청하기 때문이었습니다. 이를 수정하고자 props로 내려받은 menuData에서 url파라미터에 있는 현재 boardName과 일치하는 데이터를 찾고, 그 id를 초기값으로 변경하였습니다.

# [option] 관련 알림사항
해당 작업과 관련된 알림사항 등을 선택적으로 입력합니다.
