### PR TITLE
[fix/240831] 버그 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -123,7 +123,10 @@ function App() {
 										<UserEdit userData={userData} setIsLogin={setIsLogin} />
 									}
 								/>
-								<Route path="/admin" element={<Admin />} />
+								<Route
+									path="/admin"
+									element={<Admin fetchMenuData={fetchMenuData} />}
+								/>
 							</Routes>
 						)}
 					</main>

--- a/client/src/components/AdminBoardItem.tsx
+++ b/client/src/components/AdminBoardItem.tsx
@@ -26,7 +26,14 @@ const InnerList = React.memo(function InnerList({
 	));
 });
 
-function AdminBoardItem({ board, category, index, editData, fetchData }: any) {
+function AdminBoardItem({
+	board,
+	category,
+	index,
+	editData,
+	fetchData,
+	fetchMenuData,
+}: any) {
 	const api = process.env.REACT_APP_API_URL;
 	const [newCategory, setNewCategory] = useState("");
 	const [isEdit, setIsEdit] = useState(false);
@@ -84,6 +91,9 @@ function AdminBoardItem({ board, category, index, editData, fetchData }: any) {
 		if (isBoardDelete) {
 			board["isDeleted"] = true;
 			setIsDelete(true);
+			alert(
+				"게시판을 삭제했습니다. 게시글 수정완료를 클릭하셔야 최종 반영됩니다."
+			);
 		} else {
 			alert("게시판 삭제를 취소했습니다.");
 		}

--- a/client/src/components/EditorUnit.tsx
+++ b/client/src/components/EditorUnit.tsx
@@ -30,19 +30,6 @@ const EditorUnit = React.forwardRef((props: any, ref) => {
 		callback사용용도: 이미지를 먼저 서버에 업로드하여 응답으로 오는 url이나 파일명을 html에 처리한다.
 		*/
 
-		console.log("이미지 업로드 실행");
-
-		// //blob데이터 저장
-		// props.setBlobData(blob);
-
-		// //일단 이미지 그대로 두기
-		// const reader = new FileReader();
-		// reader.readAsDataURL(blob);
-		// reader.onloadend = () => {
-		// 	const base64data = reader.result;
-		// 	callback(`${base64data}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
-		// };
-
 		//이미지 API 적용
 		//이미지 대체 텍스트 처리
 		const blobName = blob.name === "" ? "사용자 이미지" : blob.name;

--- a/client/src/components/EditorUnit.tsx
+++ b/client/src/components/EditorUnit.tsx
@@ -9,6 +9,7 @@ import axios from "axios";
 type HookCallback = (url: string, text?: string) => void;
 
 const EditorUnit = React.forwardRef((props: any, ref) => {
+	const api = process.env.REACT_APP_API_URL;
 	const editorRef = useRef<Editor>(null);
 	const latestBoardDataRef = useRef(props.nowBoardData); // 최신 상태를 저장할 ref
 
@@ -22,21 +23,46 @@ const EditorUnit = React.forwardRef((props: any, ref) => {
 	}));
 
 	const handleImageUpload = (blob: Blob | any, callback: HookCallback) => {
-		//실행되는 시점: 이미지를 업로드하고 '확인'버튼을 클릭했을 때.
-		//callback이 실행되지 않으면 이미지 업로드 창이 닫히지 않는다.
-		//callback(`${blob.name}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
-		//callback사용용도: 이미지를 먼저 서버에 업로드하여 응답으로 오는 url이나 파일명을 html에 처리한다.
+		/*
+		실행되는 시점: 이미지를 업로드하고 '확인'버튼을 클릭했을 때, 이미지 붙여넣기 했을 때
+		-> callback이 실행되지 않으면 이미지 업로드 창이 닫히지 않는다.
+		callback(`${blob.name}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
+		callback사용용도: 이미지를 먼저 서버에 업로드하여 응답으로 오는 url이나 파일명을 html에 처리한다.
+		*/
 
-		//blob데이터 저장
-		props.setBlobData(blob);
+		console.log("이미지 업로드 실행");
 
-		//일단 이미지 그대로 두기
-		const reader = new FileReader();
-		reader.readAsDataURL(blob);
-		reader.onloadend = () => {
-			const base64data = reader.result;
-			callback(`${base64data}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
+		// //blob데이터 저장
+		// props.setBlobData(blob);
+
+		// //일단 이미지 그대로 두기
+		// const reader = new FileReader();
+		// reader.readAsDataURL(blob);
+		// reader.onloadend = () => {
+		// 	const base64data = reader.result;
+		// 	callback(`${base64data}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
+		// };
+
+		//이미지 API 적용
+		//이미지 대체 텍스트 처리
+		const blobName = blob.name === "" ? "사용자 이미지" : blob.name;
+		const newFormData = new FormData();
+		newFormData.append("file", blob);
+		const postAxiosConfig = {
+			headers: {
+				"Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
+			},
 		};
+		axios
+			.post(`${api}/api/v1/file`, newFormData, postAxiosConfig)
+			.then((response) => {
+				console.log(response.data.data.url);
+				callback(`${response.data.data.url}`, `${blobName}`); //이미지 저장된 url, img 대체 텍스트
+			})
+			.catch((error) => {
+				console.log(error);
+				alert("이미지가 정상적으로 업로드 되지 않았습니다.");
+			});
 	};
 
 	return (

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -27,6 +27,7 @@ const InnerList = React.memo(function InnerList({
 	editCategory,
 	editData,
 	fetchData,
+	fetchMenuData,
 }: any) {
 	return (
 		<AdminBoardItem
@@ -36,11 +37,12 @@ const InnerList = React.memo(function InnerList({
 			editCategory={editCategory}
 			editData={editData}
 			fetchData={fetchData}
+			fetchMenuData={fetchMenuData}
 		/>
 	);
 });
 
-const Admin = () => {
+const Admin = ({ fetchMenuData }: { fetchMenuData: () => Promise<void> }) => {
 	const api = process.env.REACT_APP_API_URL;
 	const navigate = useNavigate();
 	const [boardListData, setBoardListData] = useState<any>(null);
@@ -89,7 +91,9 @@ const Admin = () => {
 			)
 			.then((response) => {
 				alert("게시판이 추가되었습니다.");
+				setNewBoard("");
 				fetchDataMap();
+				fetchMenuData();
 			})
 			.catch((error) => {
 				console.error("에러", error);
@@ -245,7 +249,6 @@ const Admin = () => {
 			boardDataArray.push(nowBoard);
 		}
 
-		console.log(boardDataArray);
 		const postAxiosConfig = {
 			headers: {
 				"Content-Type": "application/json",
@@ -261,6 +264,7 @@ const Admin = () => {
 			.then((response) => {
 				alert("게시판 수정이 완료되었습니다.");
 				fetchDataMap();
+				fetchMenuData();
 			})
 			.catch((err) => {
 				console.log(err);
@@ -293,6 +297,7 @@ const Admin = () => {
 											index={index}
 											editData={editData}
 											fetchData={fetchDataMap}
+											fetchMenuData={fetchMenuData}
 										/>
 									);
 								})}

--- a/client/src/pages/BoardDetailEdit.tsx
+++ b/client/src/pages/BoardDetailEdit.tsx
@@ -59,15 +59,15 @@ const BoardDetailEdit = () => {
 			.catch((error) => {
 				console.error("에러", error);
 			});
-		//카테고리 목록 받아오기
-		axios
-			.get(`${api}/api/v1/category/${boardId}`)
-			.then((response) => {
-				setCategoryItem(response.data.data);
-			})
-			.catch((error) => {
-				console.error("에러", error);
-			});
+		// //카테고리 목록 받아오기: 삭제
+		// axios
+		// 	.get(`${api}/api/v1/category/${boardId}`)
+		// 	.then((response) => {
+		// 		setCategoryItem(response.data.data);
+		// 	})
+		// 	.catch((error) => {
+		// 		console.error("에러", error);
+		// 	});
 	}, []);
 	//카테고리 선택
 	const handleSelectCategory = (categoryName: string) => {
@@ -84,54 +84,24 @@ const BoardDetailEdit = () => {
 	//제출
 	const submitHandler = () => {
 		const editorData: string = editorRef.current!.getInstance().getHTML(); //작성된 데이터
-		const form: FormType =
-			nowCategoryId > 0
-				? {
-						title: titleValue,
-						content: editorData,
-						categoryId: nowCategoryId,
-				  }
-				: {
-						title: titleValue,
-						content: editorData,
-				  };
+		const form: FormType = {
+			title: titleValue,
+			content: editorData,
+		};
 
-		const formData = new FormData();
-		formData.append(
-			"data",
-			new Blob([JSON.stringify(form)], {
-				type: "application/json",
-			})
-		);
 		const postAxiosConfig = {
 			headers: {
-				"Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
 				Authorization: `${getAccessToken()}`,
 			},
 		};
 		axios
-			.patch(
-				`${api}/api/v1/post/update/${params.postId}`, //240828임시URL변경
-				formData,
-				postAxiosConfig
-			)
+			.patch(`${api}/api/v1/post/${params.postId}`, form, postAxiosConfig)
 			.then((_) => {
 				navigate(`/${params.postId}`);
 			})
 			.catch((error) => {
-				if (error.response) {
-					// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
-					console.error("서버 응답 에러:", error.response.data);
-					console.error("응답 상태 코드:", error.response.status);
-					console.error("응답 헤더:", error.response.headers);
-				} else if (error.request) {
-					// 요청이 전혀 되지 않았을 경우
-					console.error("요청 에러:", error.request);
-				} else {
-					// 설정에서 문제가 있어 요청이 전송되지 않은 경우
-					console.error("Axios 설정 에러:", error.message);
-				}
-				console.error("에러 구성:", error.config);
+				console.log(error);
+				alert("게시글 등록에 실패했습니다.");
 			});
 	};
 

--- a/client/src/pages/BoardWrite.tsx
+++ b/client/src/pages/BoardWrite.tsx
@@ -161,99 +161,26 @@ const BoardWrite = () => {
 		//데이터 전송시 설정값, 토큰
 		const postAxiosConfig = {
 			headers: {
-				"Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
+				// "Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
 				Authorization: `${getAccessToken()}`,
 			},
 		};
 
-		//이미지 없는 경우
-		if (filesFormData.get("files") === null) {
-			const postData = {
-				title: titleValue,
-				content: editorData,
-				boardId: id,
-			};
-			const newFormData: FormData = new FormData();
-			newFormData.append(
-				"data",
-				new Blob([JSON.stringify(postData)], {
-					type: "application/json",
-				})
-			);
-			axios
-				.post(`${api}/api/v1/post/create`, newFormData, postAxiosConfig) //240828임시URL변경
-				.then((response) => {
-					const newPostId = response.data.data.id;
-					navigate(`/${newPostId}`);
-				})
-				.catch((error) => {
-					alert("게시판 등록을 실패했습니다.");
-				});
-		} else {
-			//이미지 있는 경우
-			let postData = {
-				title: "images",
-				content: "",
-				boardId: id,
-			};
-			const newFormData: FormData = new FormData();
-			filesFormData.forEach((value, key) => {
-				newFormData.append(key, value);
+		const postData = {
+			title: titleValue,
+			content: editorData,
+			boardId: id,
+		};
+
+		axios
+			.post(`${api}/api/v1/post`, postData, postAxiosConfig) //240828임시URL변경
+			.then((response) => {
+				const newPostId = response.data.data.id;
+				navigate(`/${newPostId}`);
+			})
+			.catch((error) => {
+				alert("게시판 등록을 실패했습니다.");
 			});
-			newFormData.append(
-				"data",
-				new Blob([JSON.stringify(postData)], {
-					type: "application/json",
-				})
-			);
-			//1. 이미지 먼저 전송: postId, imgsUrl값 반환
-			const ImagesReponse = await uploadImage(newFormData, postAxiosConfig);
-			const [postId, filesUrls] = ImagesReponse;
-			if (postId === "" || filesUrls === "") {
-				console.log("이미지 전송 실패");
-				return;
-			}
-			console.log(postId, filesUrls);
-
-			//2. 이미지 src를 base64 -> url로 변경
-			const newContent = imgConverter(editorData, filesUrls);
-
-			//3. 이미지 최종 전송(이미지 등록시 이미 게시글 생성되었으므로 게시글 수정으로 제출)
-			postData.title = titleValue;
-			postData.content = newContent;
-			newFormData.set(
-				"data",
-				new Blob([JSON.stringify(postData)], {
-					type: "application/json",
-				})
-			);
-
-			axios
-				.patch(
-					`${api}/api/v1/post/update/${postId}`, //240828임시URL변경
-					newFormData,
-					postAxiosConfig
-				)
-				.then((_) => {
-					navigate(`/board/${nowBoardData!.name}`);
-				})
-				.catch((error) => {
-					alert("게시판 등록을 실패했습니다.");
-					if (error.response) {
-						// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
-						console.error("서버 응답 에러:", error.response.data);
-						console.error("응답 상태 코드:", error.response.status);
-						console.error("응답 헤더:", error.response.headers);
-					} else if (error.request) {
-						// 요청이 전혀 되지 않았을 경우
-						console.error("요청 에러:", error.request);
-					} else {
-						// 설정에서 문제가 있어 요청이 전송되지 않은 경우
-						console.error("Axios 설정 에러:", error.message);
-					}
-					console.error("에러 구성:", error.config);
-				});
-		}
 	};
 
 	return (


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 관리자 게시판 데이터 생성, 수정 후 사이드 메뉴와 동기화
- 게시글 작성시 이미지 추가할 때 수정된 API 적용. 업로드 즉시 base64 ->S3 URL 로 변경
- 게시글 생성, 수정 로직 변경 및 수정된 API 적용

# 느낀 점 및 어려운 점
## 게시글 생성, 수정시 이미지 업로드 관련
기존에 다소 번거롭게 
```
1. 이미지만 모아 먼저 게시글을 생성하고, 
2. 응답으로 온 이미지 URL을 받아온 뒤
3. 게시글의 HTML 데이터를 읽어서 img src를 base64에서 URL로 바꾼다
4. 게시글 수정 API로 수정된 HTML데이터를 서버에 전송한다.
```
이렇게 처리했었습니다.
그러나 백엔드와 논의 끝에 file 전송 전용 API 를 새로 만들었습니다.
```
1. 이미지를 업로드할 때 이미지 blob데이터를 이미지 전용 API에 전송한다.
2. 응답으로 오는 URL을 받아서
3. 이미지를 업로드할 때 실행되는 에디터의 콜백함수에 해당 URL로 적용한다.
5. 이미 바뀌어진 HTML 데이터를 게시글 생성 API로 서버에 전송한다.
```
덕분에 좀 더 효율적으로 바뀌고, 사용자가 게시글을 수정할 때 이미지를 수정할 때 더욱 용이하게 바뀌었습니다.

# [option] 관련 알림사항
해당 작업과 관련된 알림사항 등을 선택적으로 입력합니다.
